### PR TITLE
Update button state also on change of URL or load

### DIFF
--- a/PTPopupWebView.podspec
+++ b/PTPopupWebView.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "PTPopupWebView"
-  s.version          = "0.4.0"
+  s.version          = "0.4.1"
   s.summary          = "Swift subclass of the UIView which provide Popup web view."
   s.homepage         = "https://github.com/pjocprac/PTPopupWebView.git"
   s.license          = 'MIT'

--- a/Pod/Classes/PTPopupWebView.swift
+++ b/Pod/Classes/PTPopupWebView.swift
@@ -475,7 +475,7 @@ open class PTPopupWebView : UIView {
     }
     
     /// Close popup view
-    open func close() {
+    @objc open func close() {
         if let delegate = delegate {
             // if delegate != nil (ex. when use PTPopupWebViewContoller)
             delegate.close()
@@ -487,6 +487,7 @@ open class PTPopupWebView : UIView {
     }
     
     
+    @objc
     internal func buttonTapped (_ sender: AnyObject) {
         if let button = sender as? UIButton, let index = buttons.index(of: button) {
             if index < buttonSettings.count {

--- a/Pod/Classes/PTPopupWebView.swift
+++ b/Pod/Classes/PTPopupWebView.swift
@@ -359,7 +359,27 @@ open class PTPopupWebView : UIView {
             button.removeObserver(self, forKeyPath: "enabled")
         }
     }
-    
+
+    fileprivate func updateButtonState() {
+        for i in 0 ..< buttonSettings.count {
+            let buttonSetting = buttonSettings[i]
+            switch buttonSetting.type {
+            case .back    :
+                // To enable the Back button, when there is history.
+                buttons[i].isEnabled = webView.canGoBack
+            case .forward :
+                // To enable the Forward button, when there is advance history.
+                buttons[i].isEnabled = webView.canGoForward
+            case .reload  :
+                // To enable the update button, after completion of reading.
+                buttons[i].isEnabled = webView.estimatedProgress == 1.0
+            default:
+                break
+            }
+        }
+    }
+
+
     override open func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
         if object is WKWebView {
             if let keyPath = keyPath {
@@ -374,27 +394,13 @@ open class PTPopupWebView : UIView {
                     }
                     break;
                 case "URL":
+                    updateButtonState()
                     break;
                 case "load":
+                    updateButtonState()
                     break;
                 case "estimatedProgress":
-                    for i in 0 ..< buttonSettings.count {
-                        let buttonSetting = buttonSettings[i]
-                        switch buttonSetting.type {
-                        case .back    :
-                            // To enable the Back button, when there is history.
-                            buttons[i].isEnabled = webView.canGoBack
-                        case .forward :
-                            // To enable the Forward button, when there is advance history.
-                            buttons[i].isEnabled = webView.canGoForward
-                        case .reload  :
-                            // To enable the update button, after completion of reading.
-                            if let change = change, let progress = change[NSKeyValueChangeKey.newKey] as? Double {
-                                buttons[i].isEnabled = progress == 1.0
-                            }
-                        default       : break
-                        }
-                    }
+                    updateButtonState()
                     break;
                 default:
                     break

--- a/Pod/Classes/PTPopupWebViewController.swift
+++ b/Pod/Classes/PTPopupWebViewController.swift
@@ -95,9 +95,13 @@ open class PTPopupWebViewController : UIViewController {
         self.contentView.addSubview(popupView)
         
         popupView.translatesAutoresizingMaskIntoConstraints = false
+        var borderItem :Any = contentView
+        if #available(iOS 11, *) {
+            borderItem = contentView.safeAreaLayoutGuide
+        }
         for attribute in attributes {
             let constraint = NSLayoutConstraint(
-                item  : contentView, attribute: attribute, relatedBy: NSLayoutRelation.equal,
+                item  : borderItem, attribute: attribute, relatedBy: NSLayoutRelation.equal,
                 toItem: popupView,   attribute: attribute, multiplier: 1.0, constant: 0.0)
             contentView.addConstraint(constraint)
             constraints[attribute] = constraint


### PR DESCRIPTION
Currently button state is not updated on changes of properties "URL" and "load" of webView. When navigating within one single page (e.g. with a "fraction"-Link like href="#xyz") no page has to be loaded which means the estimatedProgress and buttons are not updated.